### PR TITLE
Dev-centric docker-compose

### DIFF
--- a/default.env
+++ b/default.env
@@ -12,11 +12,13 @@
 # Containers started with the below value will have their names prefixed with it
 # COMPOSE_PROJECT_NAME=tb
 
+# Default files used with docker-compose commands
+# https://docs.docker.com/compose/reference/envvars/#compose_file
+# Uncommment to use development settings
+# COMPOSE_FILE=docker-compose.yml:docker-compose.dev.cpro.yml
+
 # tb-api settings
 # API_EXTERNAL_PORT=5060
 
 # cPRO settings
 # REPO_ACCESS_TOKEN=redacted
-
-# Use cPRO compose file
-# COMPOSE_FILE=docker-compose.yml:docker-compose.prod.cpro.yml

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,9 @@
+version: '3.3'
+services:
+  web:
+    command: bash -c '/wait && flask run --host 0.0.0.0 --port 5000'
+    volumes:
+      - source: ./webapp
+        target: /home/flask/app/web
+        type: bind
+        read_only: true


### PR DESCRIPTION
* Add docker-compose override for development (as opposed to deployment)
* Use `flask run` for auto-reloading webserver
* Mount code as bind volume (read only) into container