### PR TITLE
Don't reference stylesheets from `tb-mobile`

### DIFF
--- a/webapp/tbapi/tbapi/templates/base.html
+++ b/webapp/tbapi/tbapi/templates/base.html
@@ -5,8 +5,6 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
   <title>{% block title %}TB Asistente Diario{% endblock %}</title>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,700">
-  <link rel='stylesheet' href='https://tb-mobile.cirg.washington.edu/css/bootstrap.css'>  
-  <link rel='stylesheet' href='https://tb-mobile.cirg.washington.edu/css/style.css'>
 
   {% block extrahead %}{% endblock %}
 </head>


### PR DESCRIPTION
With the upcoming migration away from Bootstrap
towards custom stylesheets,
these CSS files will no longer be available on
`tb-mobile.cirg.washington.edu`.

If the styles are necessary for the `tb-api` project,
they should be downloaded from...

* https://tb-mobile.cirg.washington.edu/css/bootstrap.css
* https://tb-mobile.cirg.washington.edu/css/style.css

...and hosted on the `tb-api` machine with the rest of the project.